### PR TITLE
Publishing the Recreation Potential app to Posit Connect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-Data
-datalabs
-
 # R, RStudio
 renv/
 .Rhistory
@@ -10,3 +7,6 @@ renv/
 
 # Container
 *.sif
+
+# Posit Connect
+rsconnect/

--- a/Data/.gitignore
+++ b/Data/.gitignore
@@ -1,0 +1,4 @@
+*
+
+!.gitignore
+!README.md

--- a/Data/README.md
+++ b/Data/README.md
@@ -1,0 +1,119 @@
+# Data directory
+
+What follows is the output of the `tree` command. It provides an indication of what data is required to run the app. If you need to access this data, contact someone with access to the DataLabs data store (Joe, Chris, Simon, ...).
+
+```
+.
+├── input
+│   ├── BIODT_RP_SCOT_SCORES_ALL.csv
+│   ├── Boundary_Data
+│   │   ├── boundaries.dbf
+│   │   ├── boundaries.prj
+│   │   ├── boundaries.shp
+│   │   ├── boundaries.shx
+│   │   └── empty.tif
+│   ├── MASTER_BIODT_RP_SCOT_RASTER_VALUES.csv
+│   ├── Persona_Loaded
+│   │   ├── Hard_Recreationalist.csv
+│   │   └── Soft_Recreationalist.csv
+│   ├── Processed_Data
+│   │   ├── FIPS_I.tif
+│   │   ├── FIPS_N_Slope.tif
+│   │   ├── FIPS_N.tif
+│   │   ├── processingrasters.R
+│   │   ├── SLSRA.tif
+│   │   └── Water.tif
+│   └── Raw_Shapefile
+│       ├── abeerdeen
+│       │   └── Aberdeenshire
+│       │       ├── pub_las.cst
+│       │       ├── pub_las.dbf
+│       │       ├── pub_las.prj
+│       │       ├── pub_las.shp
+│       │       └── pub_las.shx
+│       ├── BenVorlich
+│       │   ├── BenVorlich.cpg
+│       │   ├── BenVorlich.dbf
+│       │   ├── BenVorlich.prj
+│       │   ├── BenVorlich.qmd
+│       │   ├── BenVorlich.shp
+│       │   └── BenVorlich.shx
+│       ├── Bush
+│       │   ├── Bush.cpg
+│       │   ├── Bush.dbf
+│       │   ├── Bush.prj
+│       │   ├── Bush.shp
+│       │   └── Bush.shx
+│       ├── CairngormNP
+│       │   ├── CairngormNP.dbf
+│       │   ├── CairngormNP.prj
+│       │   ├── CairngormNP.sbn
+│       │   ├── CairngormNP.sbx
+│       │   ├── CairngormNP.shp
+│       │   └── CairngormNP.shx
+│       ├── Clackmann
+│       │   ├── Clackmann.cpg
+│       │   ├── Clackmann.dbf
+│       │   ├── Clackmann.prj
+│       │   ├── Clackmann.qmd
+│       │   ├── Clackmann.shp
+│       │   └── Clackmann.shx
+│       ├── Dalncardoch1
+│       │   ├── Dalncardoch1.cpg
+│       │   ├── Dalncardoch1.dbf
+│       │   ├── Dalncardoch1.prj
+│       │   ├── Dalncardoch1.shp
+│       │   └── Dalncardoch1.shx
+│       ├── Glen Prosen Approx
+│       │   ├── Glen Prosen Approx.cpg
+│       │   ├── Glen Prosen Approx.dbf
+│       │   ├── Glen Prosen Approx.prj
+│       │   ├── Glen Prosen Approx.shp
+│       │   └── Glen Prosen Approx.shx
+│       ├── Inshriach_NNR
+│       │   ├── Inshriach_NNR.dbf
+│       │   ├── Inshriach_NNR.prj
+│       │   ├── Inshriach_NNR.sbn
+│       │   ├── Inshriach_NNR.sbx
+│       │   ├── Inshriach_NNR.shp
+│       │   └── Inshriach_NNR.shx
+│       ├── local_authority_boundaries
+│       │   ├── la_boundaries.cst
+│       │   ├── la_boundaries.dbf
+│       │   ├── la_boundaries.prj
+│       │   ├── la_boundaries.shp
+│       │   └── la_boundaries.shx
+│       ├── pub_las
+│       │   ├── pub_las.cst
+│       │   ├── pub_las.dbf
+│       │   ├── pub_las.prj
+│       │   ├── pub_las.shp
+│       │   └── pub_las.shx
+│       ├── RSPB_Abernethy
+│       │   ├── RSPB_Abernethy.cpg
+│       │   ├── RSPB_Abernethy.dbf
+│       │   ├── RSPB_Abernethy.prj
+│       │   ├── RSPB_Abernethy.qmd
+│       │   ├── RSPB_Abernethy.shp
+│       │   └── RSPB_Abernethy.shx
+│       ├── Stirlingshire
+│       │   ├── Stirlingshire.cst
+│       │   ├── Stirlingshire.dbf
+│       │   ├── Stirlingshire.prj
+│       │   ├── Stirlingshire.shp
+│       │   └── Stirlingshire.shx
+│       └── Tweed Catchment
+│           ├── Tweed Catchment.dbf
+│           ├── Tweed Catchment.prj
+│           ├── Tweed Catchment.shp
+│           └── Tweed Catchment.shx
+├── output
+│   ├── recreation_potential_Bush_CA_Play.tif
+│   ├── recreation_potential_Bush_Jan_lazy.tif
+│   ├── recreation_potential_Bush_SR_ReducedMod.tif
+│   └── temp_folder
+│       └── README.md
+└── README.md
+
+21 directories, 89 files
+```

--- a/Functions/RShiny_Functions/Server_Functions/FUNC_Server_Page1b.R
+++ b/Functions/RShiny_Functions/Server_Functions/FUNC_Server_Page1b.R
@@ -24,6 +24,9 @@ server_page1b <- function(
             } else if (grepl("\\s", input$persona_id)) {
                 output$response_sidebar <- renderText("Spaces are not allowed in the Persona ID name, use \"_\" instead")
                 return()
+            } else if (grepl("^_", input$persona_id)) {
+                output$response_sidebar <- renderText("Leading underscores are not allowed in the Persona ID name")
+                return()
             }
 
             # create a local variable for peraons

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ rsconnect::connectApiUser(server="connect-apps.ceh.ac.uk", account="<username>",
 rsconnect::deployApp(appDir=".")
 ```
 
-This will take a long time since it needs to upload a couple of gigabytes of data.
+This will take a long time since it needs to upload a couple of gigabytes of data. If you do not have access to this data, please contact Joe MR.
 
 You can repeat these steps if you make any changes.
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,22 @@ Hopefully this should format your code without crashing.
 Note that the `formatR` tool does not work for in-line comments that occur within an expression (see [here](https://yihui.org/formatr/#inline-comments-after-an-incomplete-expression-or) for an explanation.
 
 
+## Posit Connect
+
+Probably the easiest way to publish to Posit Connect is to install the R package `rsconnect` and run the following commands from the root of the repository:
+
+```R
+rsconnect::addServer("https://connect-apps.ceh.ac.uk", name="connect-apps.ceh.ac.uk")
+rsconnect::connectApiUser(server="connect-apps.ceh.ac.uk", account="<username>", apiKey="<api key>")
+rsconnect::deployApp(appDir=".")
+```
+
+This will take a long time since it needs to upload a couple of gigabytes of data.
+
+You can repeat these steps if you make any changes.
+
+See the [documentation](https://connect-apps.ceh.ac.uk/__docs__/user/publishing-r/) for further guidance (requires account with UKCEH Posit Connect).
+
 
 # Containerised Recreation Potential model
 

--- a/app.R
+++ b/app.R
@@ -1,10 +1,6 @@
 # =============================================================
 # Project Name: BIODT
-# Last Updated: 2024-11-22
-#
-# Description of this version:
-# Modification to the folder structure and scripts to reduce run-time. Added input files with Rastspats with multiple layers,
-# already standardized.
+# Last Updated: 2025-01-19 by jmarshrossney
 # =============================================================
 
 library(here)
@@ -14,6 +10,7 @@ library(sf)
 library(jsonlite)
 library(shinyjs)
 library(shiny)
+library(shinymanager)
 library(terra)
 library(units)
 #library(parallel)
@@ -90,8 +87,25 @@ ui <- fluidPage(
   )
 )
 
+credentials <- data.frame(
+  user = Sys.getenv("APP_USERNAME"),
+  password = Sys.getenv("APP_PASSWORD")
+)
+
+# Add password authorisation
+ui <- secure_app(ui)
+
 # Define main server logic
 server <- function(input, output, session) {
+
+  # Check credentials
+  # See https://datastorm-open.github.io/shinymanager/
+  res_auth <- secure_server(
+    check_credentials = check_credentials(credentials)
+  )
+  output$auth_output <- renderPrint({
+    reactiveValuesToList(res_auth)
+  })
   
   # Initialize reactive values for storing form data
   shapefile_name_global <- reactiveValues(input_text = NULL)

--- a/app.R
+++ b/app.R
@@ -3,23 +3,25 @@
 # Last Updated: 2025-01-19 by jmarshrossney
 # =============================================================
 
+library(bslib)
 library(here)
-library(tidyverse)
-library(leaflet)
-library(sf)
 library(jsonlite)
-library(shinyjs)
+library(leaflet)
 library(shiny)
+library(shinyjs)
 library(shinymanager)
+library(sf)
+library(tidyverse)
 library(terra)
 library(units)
 #library(parallel)
 
 rm(list = ls())
 
-#set directory
-
 setwd(here::here())
+
+# UKCEH theming
+devtools::source_url("https://github.com/NERC-CEH/UKCEH_shiny_theming/blob/main/theme_elements.R?raw=TRUE")
 
 # Function to check, install, and load packages
 #check_install_load <- function(pkg) {
@@ -74,11 +76,12 @@ source(paste0(home_folder, folder_utils_functions, "FUNC_other_functions.R"))
 
 # Combine all UI components
 ui <- fluidPage(
+  theme = UKCEH_theme, 
+
   # Add title, contact address and privacy notice in combined title panel + header
-  # TODO: add UKCEH logo
   fluidRow(
     style = "background-color: #f8f9fa;",
-    column(8, titlePanel("BioDT - Scotland Recreational Model")),
+    column(8, UKCEH_titlePanel("BioDT - Scotland Recreational Model")),
     column(4,
       tags$div(
         style = "padding: 10px; text-align: right;",

--- a/app.R
+++ b/app.R
@@ -74,8 +74,24 @@ source(paste0(home_folder, folder_utils_functions, "FUNC_other_functions.R"))
 
 # Combine all UI components
 ui <- fluidPage(
-  titlePanel("BioDT - Scotland Recreational Model"),
+  # Add title, contact address and privacy notice in combined title panel + header
+  # TODO: add UKCEH logo
+  fluidRow(
+    style = "background-color: #f8f9fa;",
+    column(8, titlePanel("BioDT - Scotland Recreational Model")),
+    column(4,
+      tags$div(
+        style = "padding: 10px; text-align: right;",
+        div(
+          "Information about how we process your data can be found in our ",
+          tags$a(href = "https://www.ceh.ac.uk/privacy-notice", "privacy notice", target = "_blank"),
+          ". For further information, please contact Dr Jan Dick, jand@ceh.ac.uk.")
+      )
+    )
+  ),
+
   useShinyjs(),  # Initialize shinyjs
+  
   tabsetPanel(id = "nav_panel",
               tabPanel("Area of Interest", ui_page1()),
               tabPanel("Select Persona", ui_page1b()),
@@ -84,7 +100,7 @@ ui <- fluidPage(
               tabPanel("FIPS_I", ui_page4()),
               tabPanel("Water", ui_page5()),
               tabPanel("Model Run", ui_page6())
-  )
+  ),
 )
 
 credentials <- data.frame(

--- a/app.R
+++ b/app.R
@@ -144,7 +144,7 @@ server <- function(input, output, session) {
                                                     stringsAsFactors = FALSE)
                                   )
   # Define the CSV file path to the master dataset containing raster values for reclassifying
-  csv_path <- paste0(home_folder, "Data/input/BIODT_RP_SCOT_SCORES_ALL.csv")
+  csv_path <- paste0(home_folder, "Data/input/MASTER_BIODT_RP_SCOT_RASTER_VALUES.csv")
   
   # Load the existing CSV into form_data at the start
   form_data <- reactiveVal(read.csv(csv_path, stringsAsFactors = FALSE))
@@ -231,6 +231,10 @@ server <- function(input, output, session) {
   observeEvent(input$back5, {
     updateTabsetPanel(session, "nav_panel", selected = "Water")
   })
+
+  # This helps with debugging
+  options(shiny.fullstacktrace=TRUE)
+
 }
 
 # Run the application 

--- a/app.R
+++ b/app.R
@@ -1,6 +1,6 @@
 # =============================================================
 # Project Name: BIODT
-# Last Updated: 2025-01-19 by jmarshrossney
+# Last Updated: 2025-01-21 by jmarshrossney
 # =============================================================
 
 library(bslib)
@@ -22,6 +22,15 @@ setwd(here::here())
 
 # UKCEH theming
 devtools::source_url("https://github.com/NERC-CEH/UKCEH_shiny_theming/blob/main/theme_elements.R?raw=TRUE")
+
+# Modify theme so buttons are visible...
+UKCEH_theme <- bs_add_rules(
+  UKCEH_theme,
+  ".btn {
+    color: black;
+    border-color: darkgrey; 
+  }"
+)
 
 # Function to check, install, and load packages
 #check_install_load <- function(pkg) {

--- a/renv.lock
+++ b/renv.lock
@@ -264,6 +264,23 @@
       ],
       "Hash": "40415719b5a479b87949f3aa0aee737c"
     },
+    "brew": {
+      "Package": "brew",
+      "Version": "1.0-10",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "8f4a384e19dccd8c65356dc096847b76"
+    },
+    "brio": {
+      "Package": "brio",
+      "Version": "1.1.5",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R"
+      ],
+      "Hash": "c1ee497a6d999947c2c224ae46799b1a"
+    },
     "broom": {
       "Package": "broom",
       "Version": "1.0.7",
@@ -448,6 +465,20 @@
       ],
       "Hash": "859d96e65ef198fd43e82b9628d593ef"
     },
+    "credentials": {
+      "Package": "credentials",
+      "Version": "2.0.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "askpass",
+        "curl",
+        "jsonlite",
+        "openssl",
+        "sys"
+      ],
+      "Hash": "09fd631e607a236f8cc7f9604db32cb8"
+    },
     "crosstalk": {
       "Package": "crosstalk",
       "Version": "1.2.1",
@@ -463,13 +494,13 @@
     },
     "curl": {
       "Package": "curl",
-      "Version": "6.0.1",
+      "Version": "6.1.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "e8ba62486230951fcd2b881c5be23f96"
+      "Hash": "8dd23d308c751efdf675124aad4bf5d7"
     },
     "data.table": {
       "Package": "data.table",
@@ -510,6 +541,68 @@
       ],
       "Hash": "39b2e002522bfd258039ee4e889e0fd1"
     },
+    "desc": {
+      "Package": "desc",
+      "Version": "1.4.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "R6",
+        "cli",
+        "utils"
+      ],
+      "Hash": "99b79fcbd6c4d1ce087f5c5c758b384f"
+    },
+    "devtools": {
+      "Package": "devtools",
+      "Version": "2.4.5",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "cli",
+        "desc",
+        "ellipsis",
+        "fs",
+        "lifecycle",
+        "memoise",
+        "miniUI",
+        "pkgbuild",
+        "pkgdown",
+        "pkgload",
+        "profvis",
+        "rcmdcheck",
+        "remotes",
+        "rlang",
+        "roxygen2",
+        "rversions",
+        "sessioninfo",
+        "stats",
+        "testthat",
+        "tools",
+        "urlchecker",
+        "usethis",
+        "utils",
+        "withr"
+      ],
+      "Hash": "ea5bc8b4a6a01e4f12d98b58329930bb"
+    },
+    "diffobj": {
+      "Package": "diffobj",
+      "Version": "0.3.5",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "crayon",
+        "methods",
+        "stats",
+        "tools",
+        "utils"
+      ],
+      "Hash": "bcaa8b95f8d7d01a5dedfd959ce88ab8"
+    },
     "digest": {
       "Package": "digest",
       "Version": "0.6.37",
@@ -520,6 +613,26 @@
         "utils"
       ],
       "Hash": "33698c4b3127fc9f506654607fb73676"
+    },
+    "downlit": {
+      "Package": "downlit",
+      "Version": "0.4.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "brio",
+        "desc",
+        "digest",
+        "evaluate",
+        "fansi",
+        "memoise",
+        "rlang",
+        "vctrs",
+        "withr",
+        "yaml"
+      ],
+      "Hash": "45a6a596bf0108ee1ff16a040a2df897"
     },
     "dplyr": {
       "Package": "dplyr",
@@ -578,6 +691,17 @@
         "utils"
       ],
       "Hash": "27a09ca40266a1066d62ef5402dd51d6"
+    },
+    "ellipsis": {
+      "Package": "ellipsis",
+      "Version": "0.3.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "rlang"
+      ],
+      "Hash": "bb0eec2fe32e88d9e2836c2f73ea2077"
     },
     "evaluate": {
       "Package": "evaluate",
@@ -697,6 +821,21 @@
       ],
       "Hash": "15e9634c0fcd294799e9b2e929ed1b86"
     },
+    "gert": {
+      "Package": "gert",
+      "Version": "2.1.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "askpass",
+        "credentials",
+        "openssl",
+        "rstudioapi",
+        "sys",
+        "zip"
+      ],
+      "Hash": "ae855ad6d7be20dd7b05d43d25700398"
+    },
     "ggplot2": {
       "Package": "ggplot2",
       "Version": "3.5.1",
@@ -721,6 +860,34 @@
         "withr"
       ],
       "Hash": "44c6a2f8202d5b7e878ea274b1092426"
+    },
+    "gh": {
+      "Package": "gh",
+      "Version": "1.4.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "cli",
+        "gitcreds",
+        "glue",
+        "httr2",
+        "ini",
+        "jsonlite",
+        "lifecycle",
+        "rlang"
+      ],
+      "Hash": "fbbbc48eba7a6626a08bb365e44b563b"
+    },
+    "gitcreds": {
+      "Package": "gitcreds",
+      "Version": "0.1.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R"
+      ],
+      "Hash": "ab08ac61f3e1be454ae21911eb8bc2fe"
     },
     "glue": {
       "Package": "glue",
@@ -919,6 +1086,27 @@
       ],
       "Hash": "ac107251d9d9fd72f0ca8049988f1d7f"
     },
+    "httr2": {
+      "Package": "httr2",
+      "Version": "1.1.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "R6",
+        "cli",
+        "curl",
+        "glue",
+        "lifecycle",
+        "magrittr",
+        "openssl",
+        "rappdirs",
+        "rlang",
+        "vctrs",
+        "withr"
+      ],
+      "Hash": "0f14199bbd820a9fca398f2df40994f1"
+    },
     "ids": {
       "Package": "ids",
       "Version": "1.0.1",
@@ -929,6 +1117,13 @@
         "uuid"
       ],
       "Hash": "99df65cfef20e525ed38c3d2577f7190"
+    },
+    "ini": {
+      "Package": "ini",
+      "Version": "0.3.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "6154ec2223172bce8162d4153cda21f7"
     },
     "isoband": {
       "Package": "isoband",
@@ -1149,6 +1344,18 @@
       ],
       "Hash": "18e9c28c1d3ca1560ce30658b22ce104"
     },
+    "miniUI": {
+      "Package": "miniUI",
+      "Version": "0.1.1.1",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "htmltools",
+        "shiny",
+        "utils"
+      ],
+      "Hash": "fec5f52652d60615fdb3957b3d74324a"
+    },
     "modelr": {
       "Package": "modelr",
       "Version": "0.1.11",
@@ -1231,6 +1438,21 @@
       ],
       "Hash": "15da5a8412f317beeee6175fbc76f4bb"
     },
+    "pkgbuild": {
+      "Package": "pkgbuild",
+      "Version": "1.4.6",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "R6",
+        "callr",
+        "cli",
+        "desc",
+        "processx"
+      ],
+      "Hash": "2914aa6216361f59e40d5c84667ac155"
+    },
     "pkgconfig": {
       "Package": "pkgconfig",
       "Version": "2.0.3",
@@ -1240,6 +1462,58 @@
         "utils"
       ],
       "Hash": "01f28d4278f15c76cddbea05899c5d6f"
+    },
+    "pkgdown": {
+      "Package": "pkgdown",
+      "Version": "2.1.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "bslib",
+        "callr",
+        "cli",
+        "desc",
+        "digest",
+        "downlit",
+        "fontawesome",
+        "fs",
+        "httr2",
+        "jsonlite",
+        "openssl",
+        "purrr",
+        "ragg",
+        "rlang",
+        "rmarkdown",
+        "tibble",
+        "whisker",
+        "withr",
+        "xml2",
+        "yaml"
+      ],
+      "Hash": "df2912d5873422b55a13002510f02c9f"
+    },
+    "pkgload": {
+      "Package": "pkgload",
+      "Version": "1.4.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "cli",
+        "desc",
+        "fs",
+        "glue",
+        "lifecycle",
+        "methods",
+        "pkgbuild",
+        "processx",
+        "rlang",
+        "rprojroot",
+        "utils",
+        "withr"
+      ],
+      "Hash": "2ec30ffbeec83da57655b850cf2d3e0e"
     },
     "plogr": {
       "Package": "plogr",
@@ -1257,6 +1531,13 @@
         "R"
       ],
       "Hash": "bd54ba8a0a5faded999a7aab6e46b374"
+    },
+    "praise": {
+      "Package": "praise",
+      "Version": "1.0.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "a555924add98c99d2f411e37e7d25e9f"
     },
     "prettyunits": {
       "Package": "prettyunits",
@@ -1280,6 +1561,19 @@
         "utils"
       ],
       "Hash": "0c90a7d71988856bad2a2a45dd871bb9"
+    },
+    "profvis": {
+      "Package": "profvis",
+      "Version": "0.4.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "htmlwidgets",
+        "rlang",
+        "vctrs"
+      ],
+      "Hash": "bffa126bf92987e677c12cfb5651fc1d"
     },
     "progress": {
       "Package": "progress",
@@ -1384,6 +1678,28 @@
       ],
       "Hash": "0e2829df8cb74a98179c886b023ffea8"
     },
+    "rcmdcheck": {
+      "Package": "rcmdcheck",
+      "Version": "1.4.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R6",
+        "callr",
+        "cli",
+        "curl",
+        "desc",
+        "digest",
+        "pkgbuild",
+        "prettyunits",
+        "rprojroot",
+        "sessioninfo",
+        "utils",
+        "withr",
+        "xopen"
+      ],
+      "Hash": "8f25ebe2ec38b1f2aef3b0d2ef76f6c4"
+    },
     "readr": {
       "Package": "readr",
       "Version": "2.1.5",
@@ -1438,6 +1754,20 @@
         "tibble"
       ],
       "Hash": "76c9e04c712a05848ae7a23d2f170a40"
+    },
+    "remotes": {
+      "Package": "remotes",
+      "Version": "2.5.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "methods",
+        "stats",
+        "tools",
+        "utils"
+      ],
+      "Hash": "3ee025083e66f18db6cf27b56e23e141"
     },
     "renv": {
       "Package": "renv",
@@ -1505,6 +1835,32 @@
       ],
       "Hash": "df99277f63d01c34e95e3d2f06a79736"
     },
+    "roxygen2": {
+      "Package": "roxygen2",
+      "Version": "7.3.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "R6",
+        "brew",
+        "cli",
+        "commonmark",
+        "cpp11",
+        "desc",
+        "knitr",
+        "methods",
+        "pkgload",
+        "purrr",
+        "rlang",
+        "stringi",
+        "stringr",
+        "utils",
+        "withr",
+        "xml2"
+      ],
+      "Hash": "6ee25f9054a70f44d615300ed531ba8d"
+    },
     "rprojroot": {
       "Package": "rprojroot",
       "Version": "2.0.4",
@@ -1544,6 +1900,18 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "5f90cd73946d706cfe26024294236113"
+    },
+    "rversions": {
+      "Package": "rversions",
+      "Version": "2.1.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "curl",
+        "utils",
+        "xml2"
+      ],
+      "Hash": "a9881dfed103e83f9de151dc17002cd1"
     },
     "rvest": {
       "Package": "rvest",
@@ -1633,6 +2001,19 @@
         "stringr"
       ],
       "Hash": "3838071b66e0c566d55cc26bd6e27bf4"
+    },
+    "sessioninfo": {
+      "Package": "sessioninfo",
+      "Version": "1.2.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "cli",
+        "tools",
+        "utils"
+      ],
+      "Hash": "3f9796a8d0a0e8c6eb49a4b029359d1f"
     },
     "sf": {
       "Package": "sf",
@@ -1810,6 +2191,35 @@
       ],
       "Hash": "fbeffe988419d292225a57cf9c284802"
     },
+    "testthat": {
+      "Package": "testthat",
+      "Version": "3.2.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "R6",
+        "brio",
+        "callr",
+        "cli",
+        "desc",
+        "digest",
+        "evaluate",
+        "jsonlite",
+        "lifecycle",
+        "magrittr",
+        "methods",
+        "pkgload",
+        "praise",
+        "processx",
+        "ps",
+        "rlang",
+        "utils",
+        "waldo",
+        "withr"
+      ],
+      "Hash": "42f889439ccb14c55fc3d75c9c755056"
+    },
     "textshaping": {
       "Package": "textshaping",
       "Version": "0.4.0",
@@ -1964,6 +2374,52 @@
       ],
       "Hash": "119d19da480e873f72241ff6962ffd83"
     },
+    "urlchecker": {
+      "Package": "urlchecker",
+      "Version": "1.0.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "cli",
+        "curl",
+        "tools",
+        "xml2"
+      ],
+      "Hash": "409328b8e1253c8d729a7836fe7f7a16"
+    },
+    "usethis": {
+      "Package": "usethis",
+      "Version": "3.1.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "cli",
+        "clipr",
+        "crayon",
+        "curl",
+        "desc",
+        "fs",
+        "gert",
+        "gh",
+        "glue",
+        "jsonlite",
+        "lifecycle",
+        "purrr",
+        "rappdirs",
+        "rlang",
+        "rprojroot",
+        "rstudioapi",
+        "stats",
+        "tools",
+        "utils",
+        "whisker",
+        "withr",
+        "yaml"
+      ],
+      "Hash": "0d7f5ca181f9b1e68b217bd93b6cc703"
+    },
     "utf8": {
       "Package": "utf8",
       "Version": "1.2.4",
@@ -2046,6 +2502,28 @@
       ],
       "Hash": "93e6b6c8ae3f81d4be77a0dc74e5cf5e"
     },
+    "waldo": {
+      "Package": "waldo",
+      "Version": "0.6.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "cli",
+        "diffobj",
+        "glue",
+        "methods",
+        "rlang"
+      ],
+      "Hash": "52f574062a7b66e56926988c3fbdb3b7"
+    },
+    "whisker": {
+      "Package": "whisker",
+      "Version": "0.4.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "c6abfa47a46d281a7d5159d0a8891e88"
+    },
     "withr": {
       "Package": "withr",
       "Version": "3.0.2",
@@ -2094,6 +2572,17 @@
       ],
       "Hash": "1d0336142f4cd25d8d23cd3ba7a8fb61"
     },
+    "xopen": {
+      "Package": "xopen",
+      "Version": "1.0.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "processx"
+      ],
+      "Hash": "423df1e86d5533fcb73c6b02b4923b49"
+    },
     "xtable": {
       "Package": "xtable",
       "Version": "1.8-4",
@@ -2112,6 +2601,13 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "51dab85c6c98e50a18d7551e9d49f76c"
+    },
+    "zip": {
+      "Package": "zip",
+      "Version": "2.3.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "fcc4bd8e6da2d2011eb64a5e5cc685ab"
     }
   }
 }

--- a/renv.lock
+++ b/renv.lock
@@ -63,6 +63,17 @@
       ],
       "Hash": "5122bb14d8736372411f955e1b16bc8a"
     },
+    "PKI": {
+      "Package": "PKI",
+      "Version": "0.1-14",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "base64enc"
+      ],
+      "Hash": "f5b9c6b2f62f1fa3dd53fd1ddccbb241"
+    },
     "R6": {
       "Package": "R6",
       "Version": "2.5.1",
@@ -1098,6 +1109,18 @@
       ],
       "Hash": "d413e0fef796c9401a4419485f709ca1"
     },
+    "packrat": {
+      "Package": "packrat",
+      "Version": "0.9.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "tools",
+        "utils"
+      ],
+      "Hash": "55ddd2d4a1959535f18393478b0c14a6"
+    },
     "pillar": {
       "Package": "pillar",
       "Version": "1.9.0",
@@ -1391,6 +1414,29 @@
         "R"
       ],
       "Hash": "4c8415e0ec1e29f3f4f6fc108bef0144"
+    },
+    "rsconnect": {
+      "Package": "rsconnect",
+      "Version": "1.3.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "PKI",
+        "R",
+        "cli",
+        "curl",
+        "digest",
+        "jsonlite",
+        "lifecycle",
+        "openssl",
+        "packrat",
+        "renv",
+        "rlang",
+        "rstudioapi",
+        "tools",
+        "yaml"
+      ],
+      "Hash": "d466c98fdce812325feb4ad406c6ca4b"
     },
     "rstudioapi": {
       "Package": "rstudioapi",

--- a/renv.lock
+++ b/renv.lock
@@ -20,6 +20,23 @@
       ],
       "Hash": "065ae649b05f1ff66bb0c793107508f5"
     },
+    "DT": {
+      "Package": "DT",
+      "Version": "0.33",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "crosstalk",
+        "htmltools",
+        "htmlwidgets",
+        "httpuv",
+        "jquerylib",
+        "jsonlite",
+        "magrittr",
+        "promises"
+      ],
+      "Hash": "64ff3427f559ce3f2597a4fe13255cb6"
+    },
     "KernSmooth": {
       "Package": "KernSmooth",
       "Version": "2.23-24",
@@ -74,6 +91,45 @@
       ],
       "Hash": "f5b9c6b2f62f1fa3dd53fd1ddccbb241"
     },
+    "R.methodsS3": {
+      "Package": "R.methodsS3",
+      "Version": "1.8.2",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "utils"
+      ],
+      "Hash": "278c286fd6e9e75d0c2e8f731ea445c8"
+    },
+    "R.oo": {
+      "Package": "R.oo",
+      "Version": "1.27.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "R.methodsS3",
+        "methods",
+        "utils"
+      ],
+      "Hash": "6ac79ff194202248cf946fe3a5d6d498"
+    },
+    "R.utils": {
+      "Package": "R.utils",
+      "Version": "2.12.3",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "R.methodsS3",
+        "R.oo",
+        "methods",
+        "tools",
+        "utils"
+      ],
+      "Hash": "3dc2829b790254bfba21e60965787651"
+    },
     "R6": {
       "Package": "R6",
       "Version": "2.5.1",
@@ -93,6 +149,25 @@
         "R"
       ],
       "Hash": "45f0398006e83a5b10b72a90663d8d8c"
+    },
+    "RSQLite": {
+      "Package": "RSQLite",
+      "Version": "2.3.9",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "DBI",
+        "R",
+        "bit64",
+        "blob",
+        "cpp11",
+        "memoise",
+        "methods",
+        "pkgconfig",
+        "plogr",
+        "rlang"
+      ],
+      "Hash": "52294139fc7a21bca806b49ae2f315ca"
     },
     "Rcpp": {
       "Package": "Rcpp",
@@ -134,6 +209,24 @@
         "R"
       ],
       "Hash": "543776ae6848fde2f48ff3816d0628bc"
+    },
+    "billboarder": {
+      "Package": "billboarder",
+      "Version": "0.5.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "ggplot2",
+        "htmltools",
+        "htmlwidgets",
+        "jsonlite",
+        "magrittr",
+        "rlang",
+        "scales",
+        "shiny"
+      ],
+      "Hash": "8cfc73709bd06a57f4039fe15083b238"
     },
     "bit": {
       "Package": "bit",
@@ -1148,6 +1241,13 @@
       ],
       "Hash": "01f28d4278f15c76cddbea05899c5d6f"
     },
+    "plogr": {
+      "Package": "plogr",
+      "Version": "0.2.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "09eb987710984fc2905c7129c7d85e65"
+    },
     "png": {
       "Package": "png",
       "Version": "0.1-8",
@@ -1510,6 +1610,17 @@
       ],
       "Hash": "c19df082ba346b0ffa6f833e92de34d1"
     },
+    "scrypt": {
+      "Package": "scrypt",
+      "Version": "0.1.6",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "Rcpp"
+      ],
+      "Hash": "5669c376aea6546ff938528588101b7a"
+    },
     "selectr": {
       "Package": "selectr",
       "Version": "0.4-2",
@@ -1591,6 +1702,25 @@
         "shiny"
       ],
       "Hash": "802e4786b353a4bb27116957558548d5"
+    },
+    "shinymanager": {
+      "Package": "shinymanager",
+      "Version": "1.0.410",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "DBI",
+        "DT",
+        "R.utils",
+        "R6",
+        "RSQLite",
+        "billboarder",
+        "htmltools",
+        "openssl",
+        "scrypt",
+        "shiny"
+      ],
+      "Hash": "7992f5ecc5e8d40200dc8ba4e97d33eb"
     },
     "sourcetools": {
       "Package": "sourcetools",


### PR DESCRIPTION
There is a fairly urgent need to publish this app, in its current 'un-polished' state, so that it can be played around with by some members of the public who have generously signed up to participate in a study this winter/spring.

Publishing the app through DataLabs was not feasible because DataLabs does not allow write access to the filesystem associated with the published app. We would have needed to very quickly reformulate the app to use remote storage. (In fact I think it is still a good idea to let users use Google sheets for their persona configurations, but there are many other places where data is written to disk that are more complicated to fix).

It is very fortunate that the app seems to work as-is when published through Posit Connect. This PR implements the most basic requirements for doing this, with some minimal documentation.

- [x] Add minimal instructions for publishing to Posit Connect
- [x] Include instructions for adding the `Data/` directory, which is not tracked by git
- [x] #5 
- [x] #15 
- [x] #17 
- [x] Sanity check by colleagues that this works as expected