### PR TITLE
Fix bug in appending personas to existing file

### DIFF
--- a/model/tests/testthat/test_io.R
+++ b/model/tests/testthat/test_io.R
@@ -49,6 +49,16 @@ test_that("appending a person", {
 
     save_persona(persona1, test_file, "persona1")
     save_persona(persona2, test_file, "persona2")
+
+    expect_true(file.exists(test_file))
+
+    loaded_persona1 <- load_persona(test_file, name = "persona1")
+    loaded_persona2 <- load_persona(test_file, name = "persona2")
+
+    expect_equal(loaded_persona1, persona1)
+    expect_equal(loaded_persona2, persona2)
+
+    unlink(test_file)
 })
 
 # TODO:

--- a/notebooks/save_load.qmd
+++ b/notebooks/save_load.qmd
@@ -1,0 +1,81 @@
+---
+title: Test save/load round trip
+format:
+  html:
+    embed-resources: true
+---
+
+## This is broken
+
+```{r}
+devtools::load_all("../model")
+
+test_file <- tempfile(fileext = ".csv")
+
+config <- load_config()
+persona_1 <- setNames(sample(0:10, size = 87, replace = TRUE), config[["Name"]])
+persona_2 <- setNames(sample(0:10, size = 87, replace = TRUE), config[["Name"]])
+
+save_persona(persona_1, test_file, name = "persona_1")
+save_persona(persona_2, test_file, name = "persona_2")
+
+loaded_persona_1 <- load_persona(test_file, name = "persona_1")
+loaded_persona_2 <- load_persona(test_file, name = "persona_2")
+
+# NOTE: cbind outputs a matrix (not a data.frame)
+#rbind(persona_1, loaded_persona_1)
+cbind(persona_1, loaded_persona_1)
+```
+
+## Test cbind for aligning by name
+
+```{r}
+cbind(persona_1, persona_1)[1:5,]
+
+# They are not aligned!
+persona_1_shuffled <- persona_1[sample.int(87)]
+cbind(persona_1, persona_1_shuffled)[1:5,]
+
+# But we can manually realign using names(existing_structure)
+persona_1_realigned <- persona_1_shuffled[names(persona_1)]
+cbind(persona_1, persona_1_realigned)[1:5,]
+```
+
+```{r}
+# Test append to a matrix
+mat <- cbind(persona_1, persona_2)
+
+# NOTE: need to use `rownames` for matrix instead of `names`!!
+persona_1_realigned_2 <- persona_1_shuffled[rownames(mat)]
+cbind(mat, persona_1_realigned_2)[1:5,]
+```
+
+Are matrix objects good enough?
+How do you index them?
+
+```{r}
+mat["Water_Rivers_1",]
+mat["Water_Rivers_1","persona_1"]
+```
+
+## Does it work for data.frame?
+
+```{r}
+# Test append to a matrix
+df <- as.data.frame(cbind(persona_1, persona_2))
+
+# NOTE: need to use `rownames` for matrix instead of `names`!!
+persona_1_realigned_2 <- persona_1_shuffled[rownames(mat)]
+cbind(mat, persona_1_realigned_2)[1:5,]
+```
+
+## Testing a potential fix
+
+```r
+persona_3 <- setNames(sample(0:10, size = 87, replace = TRUE), config[["Name"]])
+data.frame(index = names(persona_3), persona_3 = persona_3)
+```
+
+```{r}
+df <- 1
+```


### PR DESCRIPTION
Despite massively overengineering the code for appending personas to existing files, it was still buggy.

100% my fault - I did not bother finishing the unit test that would have caught it! That being said, I am surprised that R does not throw a warning when using `cbind` on objects that have the same row names but in a different order  :-|
